### PR TITLE
Renamed Minicloner.Tests.Fakes.AccessModifiers namespace to Minicloner.Tests.Fakes.Fields

### DIFF
--- a/src/Minicloner/Minicloner.Tests/Classes/CloneClassesAccessModifiersTests.cs
+++ b/src/Minicloner/Minicloner.Tests/Classes/CloneClassesAccessModifiersTests.cs
@@ -1,5 +1,5 @@
 ﻿using Minicloner.Test.OtherAssembly.Fakes;
-using Minicloner.Tests.Fakes.AccessModifiers;
+using Minicloner.Tests.Fakes.Fields;
 using Xunit;
 
 namespace Minicloner.Tests.Classes

--- a/src/Minicloner/Minicloner.Tests/Fakes/Fields/Class_With_InternalField.cs
+++ b/src/Minicloner/Minicloner.Tests/Fakes/Fields/Class_With_InternalField.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Minicloner.Tests.Fakes.AccessModifiers
+namespace Minicloner.Tests.Fakes.Fields
 {
     public class Class_With_InternalField
     {

--- a/src/Minicloner/Minicloner.Tests/Fakes/Fields/Class_With_PrivateField.cs
+++ b/src/Minicloner/Minicloner.Tests/Fakes/Fields/Class_With_PrivateField.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Minicloner.Tests.Fakes.AccessModifiers
+namespace Minicloner.Tests.Fakes.Fields
 {
     public class Class_With_PrivateField
     {

--- a/src/Minicloner/Minicloner.Tests/Fakes/Fields/Class_With_ProtectedField.cs
+++ b/src/Minicloner/Minicloner.Tests/Fakes/Fields/Class_With_ProtectedField.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Minicloner.Tests.Fakes.AccessModifiers
+namespace Minicloner.Tests.Fakes.Fields
 {
     public class Class_With_ProtectedField
     {

--- a/src/Minicloner/Minicloner.Tests/Fakes/Fields/Class_With_ProtectedInternalField.cs
+++ b/src/Minicloner/Minicloner.Tests/Fakes/Fields/Class_With_ProtectedInternalField.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Minicloner.Tests.Fakes.AccessModifiers
+namespace Minicloner.Tests.Fakes.Fields
 {
     public class Class_With_ProtectedInternalField
     {

--- a/src/Minicloner/Minicloner.Tests/Fakes/Fields/Class_With_PublicField.cs
+++ b/src/Minicloner/Minicloner.Tests/Fakes/Fields/Class_With_PublicField.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Minicloner.Tests.Fakes.AccessModifiers
+namespace Minicloner.Tests.Fakes.Fields
 {
     public class Class_With_PublicField
     {

--- a/src/Minicloner/Minicloner.Tests/Minicloner.Tests.csproj
+++ b/src/Minicloner/Minicloner.Tests/Minicloner.Tests.csproj
@@ -54,11 +54,11 @@
     <Compile Include="Classes\CloneClassesAccessModifiersTests.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Fakes\AccessModifiers\Class_With_InternalField.cs" />
-    <Compile Include="Fakes\AccessModifiers\Class_With_PrivateField.cs" />
-    <Compile Include="Fakes\AccessModifiers\Class_With_ProtectedInternalField.cs" />
-    <Compile Include="Fakes\AccessModifiers\Class_With_ProtectedField.cs" />
-    <Compile Include="Fakes\AccessModifiers\Class_With_PublicField.cs" />
+    <Compile Include="Fakes\Fields\Class_With_InternalField.cs" />
+    <Compile Include="Fakes\Fields\Class_With_PrivateField.cs" />
+    <Compile Include="Fakes\Fields\Class_With_ProtectedInternalField.cs" />
+    <Compile Include="Fakes\Fields\Class_With_ProtectedField.cs" />
+    <Compile Include="Fakes\Fields\Class_With_PublicField.cs" />
     <Compile Include="Fakes\EmptyStruct.cs" />
     <Compile Include="Fakes\Class_Without_ParameterlessConstructor.cs" />
     <Compile Include="Fakes\Properties\Class_With_PrivateGetter.cs" />


### PR DESCRIPTION
Closes #28
