### PR TITLE
- Renamed StringReflectionHelper.cs to StringReflectionExtensions.cs

### DIFF
--- a/src/Minicloner/Minicloner/FormatterServices.cs
+++ b/src/Minicloner/Minicloner/FormatterServices.cs
@@ -18,6 +18,6 @@ namespace Minicloner
                 .GetMethod("GetUninitializedObject", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
                 .CreateDelegate(typeof(Func<Type, object>));
 
-        public static object GetUninitializedObject(Type type) => GetUninitializedObjectDelegate.Invoke(type);
+        public static object GetUninitializedObject(Type type) => GetUninitializedObjectDelegate(type);
     }
 }

--- a/src/Minicloner/Minicloner/StringReflectionExtensions.cs
+++ b/src/Minicloner/Minicloner/StringReflectionExtensions.cs
@@ -9,7 +9,7 @@ namespace Minicloner
     /// </summary>
     static class StringReflectionExtensions
     {
-        public static readonly Func<string, string> CopyDelagate =
+        public static readonly Func<string, string> CopyDelegate =
             (Func<string, string>)
                 typeof(String)
                     .GetTypeInfo()
@@ -18,6 +18,6 @@ namespace Minicloner
                     .GetMethod("Copy", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
                     .CreateDelegate(typeof(Func<string, string>));
 
-        public static string Copy(this string str) => CopyDelagate.Invoke(str);
+        public static string Copy(this string str) => CopyDelegate(str);
     }
 }


### PR DESCRIPTION
- Fixed typo in CopyDelegate delegate
- Removed redundant .Invoke call on StringReflectionExtensions.CopyDelegate(str) and FormatterServices.GetUninitializedObjectDelegate(type)
  Closes #51
