### PR TITLE
- Changed type names to aliases where possible. Closes #77

### DIFF
--- a/Minicloner.sln
+++ b/Minicloner.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.9
+VisualStudioVersion = 15.0.26228.10
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7EC6BFED-E3FC-408A-B4EF-ABAB4BE9C04A}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/Minicloner/FormatterServices.cs
+++ b/src/Minicloner/FormatterServices.cs
@@ -7,16 +7,16 @@ namespace Minicloner
     /// Hack to fix the problem of not having FormatterServices class in netstandard1.6
     /// Based on https://github.com/dotnet/corefx/issues/7938#issuecomment-227580931
     /// </summary>
-    static class FormatterServices
+    internal static class FormatterServices
     {
         private static readonly Func<Type, object> GetUninitializedObjectDelegate =
-        (Func<Type, object>)
-            typeof(string)
-                .GetTypeInfo()
-                .Assembly
-                .GetType("System.Runtime.Serialization.FormatterServices")
-                .GetMethod("GetUninitializedObject", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
-                .CreateDelegate(typeof(Func<Type, object>));
+            (Func<Type, object>)
+                typeof(string)
+                    .GetTypeInfo()
+                    .Assembly
+                    .GetType("System.Runtime.Serialization.FormatterServices")
+                    .GetMethod("GetUninitializedObject", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
+                    .CreateDelegate(typeof(Func<Type, object>));
 
         public static object GetUninitializedObject(Type type) => GetUninitializedObjectDelegate(type);
     }

--- a/src/Minicloner/StringReflectionExtensions.cs
+++ b/src/Minicloner/StringReflectionExtensions.cs
@@ -7,11 +7,11 @@ namespace Minicloner
     /// Hack class to fix the problem of not having String.Copy(string str) in netstandard1.6
     /// Based on https://github.com/dotnet/corefx/issues/7938#issuecomment-227580931
     /// </summary>
-    static class StringReflectionExtensions
+    internal static class StringReflectionExtensions
     {
-        public static readonly Func<string, string> CopyDelegate =
+        private static readonly Func<string, string> CopyDelegate =
             (Func<string, string>)
-                typeof(String)
+                typeof(string)
                     .GetTypeInfo()
                     .Assembly
                     .GetType("System.String")

--- a/test/Minicloner.Tests.OtherAssembly/Fakes/Constructors/Class_With_InternalParameterlessConstructor_From_OtherAssembly.cs
+++ b/test/Minicloner.Tests.OtherAssembly/Fakes/Constructors/Class_With_InternalParameterlessConstructor_From_OtherAssembly.cs
@@ -1,11 +1,9 @@
-﻿using System;
-
-namespace Minicloner.Tests.OtherAssembly.Fakes.Constructors
+﻿namespace Minicloner.Tests.OtherAssembly.Fakes.Constructors
 {
     public class Class_With_InternalParameterlessConstructor_From_OtherAssembly
     {
-        public Int32 Int32Property { get; set; }
-        public Int32 PropertyInitializedInConstructor { get; private set; }
+        public int Int32Property { get; set; }
+        public int PropertyInitializedInConstructor { get; private set; }
 
         internal Class_With_InternalParameterlessConstructor_From_OtherAssembly()
         {

--- a/test/Minicloner.Tests.OtherAssembly/Fakes/Constructors/Class_With_ProtectedInternalParameterlessConstructor_From_OtherAssembly.cs
+++ b/test/Minicloner.Tests.OtherAssembly/Fakes/Constructors/Class_With_ProtectedInternalParameterlessConstructor_From_OtherAssembly.cs
@@ -1,11 +1,9 @@
-﻿using System;
-
-namespace Minicloner.Tests.OtherAssembly.Fakes.Constructors
+﻿namespace Minicloner.Tests.OtherAssembly.Fakes.Constructors
 {
     public class Class_With_ProtectedInternalParameterlessConstructor_From_OtherAssembly
     {
-        public Int32 Int32Property { get; set; }
-        public Int32 PropertyInitializedInConstructor { get; private set; }
+        public int Int32Property { get; set; }
+        public int PropertyInitializedInConstructor { get; private set; }
 
         protected internal Class_With_ProtectedInternalParameterlessConstructor_From_OtherAssembly()
         {

--- a/test/Minicloner.Tests.OtherAssembly/Fakes/Fields/Class_With_InternalField_From_OtherAssembly.cs
+++ b/test/Minicloner.Tests.OtherAssembly/Fakes/Fields/Class_With_InternalField_From_OtherAssembly.cs
@@ -1,16 +1,14 @@
-using System;
-
 namespace Minicloner.Tests.OtherAssembly.Fakes.Fields
 {
     public class Class_With_InternalField_From_OtherAssembly
     {
-        internal Int32 InternalField;
+        internal int InternalField;
 
-        public Class_With_InternalField_From_OtherAssembly(Int32 parameter)
+        public Class_With_InternalField_From_OtherAssembly(int parameter)
         {
             InternalField = parameter;
         }
 
-        public Int32 Get_InternalField() => InternalField;
+        public int Get_InternalField() => InternalField;
     }
 }

--- a/test/Minicloner.Tests.OtherAssembly/Fakes/Fields/Class_With_ProtectedInternalField_From_OtherAssembly.cs
+++ b/test/Minicloner.Tests.OtherAssembly/Fakes/Fields/Class_With_ProtectedInternalField_From_OtherAssembly.cs
@@ -1,16 +1,14 @@
-using System;
-
 namespace Minicloner.Tests.OtherAssembly.Fakes.Fields
 {
     public class Class_With_ProtectedInternalField_From_OtherAssembly
     {
-        protected internal Int32 ProtectedInternalField;
+        protected internal int ProtectedInternalField;
 
-        public Class_With_ProtectedInternalField_From_OtherAssembly(Int32 parameter)
+        public Class_With_ProtectedInternalField_From_OtherAssembly(int parameter)
         {
             ProtectedInternalField = parameter;
         }
 
-        public Int32 Get_ProtectedInternalField() => ProtectedInternalField;
+        public int Get_ProtectedInternalField() => ProtectedInternalField;
     }
 }

--- a/test/Minicloner.Tests.OtherAssembly/Fakes/Inheritance/BaseClass_With_InternalField_From_OtherAssembly.cs
+++ b/test/Minicloner.Tests.OtherAssembly/Fakes/Inheritance/BaseClass_With_InternalField_From_OtherAssembly.cs
@@ -1,16 +1,14 @@
-﻿using System;
-
-namespace Minicloner.Tests.OtherAssembly.Fakes.Inheritance
+﻿namespace Minicloner.Tests.OtherAssembly.Fakes.Inheritance
 {
     public class BaseClass_With_InternalField_From_OtherAssembly
     {
-        internal Int32 InternalField_In_BaseClass;
+        internal int InternalField_In_BaseClass;
 
-        public void Set_InternalField_In_BaseClass(Int32 int32Parameter)
+        public void Set_InternalField_In_BaseClass(int int32Parameter)
         {
             InternalField_In_BaseClass = int32Parameter;
         }
 
-        public Int32 Get_InternalField_In_BaseClass() => InternalField_In_BaseClass;
+        public int Get_InternalField_In_BaseClass() => InternalField_In_BaseClass;
     }
 }

--- a/test/Minicloner.Tests.OtherAssembly/Fakes/Inheritance/BaseClass_With_ProtectedInternalField_From_OtherAssembly.cs
+++ b/test/Minicloner.Tests.OtherAssembly/Fakes/Inheritance/BaseClass_With_ProtectedInternalField_From_OtherAssembly.cs
@@ -1,16 +1,14 @@
-﻿using System;
-
-namespace Minicloner.Tests.OtherAssembly.Fakes.Inheritance
+﻿namespace Minicloner.Tests.OtherAssembly.Fakes.Inheritance
 {
     public class BaseClass_With_ProtectedInternalField_From_OtherAssembly
     {
-        protected internal Int32 ProtectedInternalField_In_BaseClass;
+        protected internal int ProtectedInternalField_In_BaseClass;
 
-        public void Set_ProtectedInternalField_In_BaseClass(Int32 int32Parameter)
+        public void Set_ProtectedInternalField_In_BaseClass(int int32Parameter)
         {
             ProtectedInternalField_In_BaseClass = int32Parameter;
         }
 
-        public Int32 Get_ProtectedInternalField_In_BaseClass() => ProtectedInternalField_In_BaseClass;
+        public int Get_ProtectedInternalField_In_BaseClass() => ProtectedInternalField_In_BaseClass;
     }
 }

--- a/test/Minicloner.Tests.OtherAssembly/Fakes/Inheritance/DerivedClass_With_InternalField_From_OtherAssembly.cs
+++ b/test/Minicloner.Tests.OtherAssembly/Fakes/Inheritance/DerivedClass_With_InternalField_From_OtherAssembly.cs
@@ -1,16 +1,14 @@
-﻿using System;
-
-namespace Minicloner.Tests.OtherAssembly.Fakes.Inheritance
+﻿namespace Minicloner.Tests.OtherAssembly.Fakes.Inheritance
 {
     public class DerivedClass_With_InternalField_From_OtherAssembly : BaseClass_With_InternalField_From_OtherAssembly
     {
-        internal Int32 InternalField_In_DerivedClass;
+        internal int InternalField_In_DerivedClass;
 
-        public void Set_InternalField_In_DerivedClass(Int32 int32Parameter)
+        public void Set_InternalField_In_DerivedClass(int int32Parameter)
         {
             InternalField_In_DerivedClass = int32Parameter;
         }
 
-        public Int32 Get_InternalField_In_DerivedClass() => InternalField_In_DerivedClass;
+        public int Get_InternalField_In_DerivedClass() => InternalField_In_DerivedClass;
     }
 }

--- a/test/Minicloner.Tests.OtherAssembly/Fakes/Inheritance/DerivedClass_With_ProtectedInternalField_From_OtherAssembly.cs
+++ b/test/Minicloner.Tests.OtherAssembly/Fakes/Inheritance/DerivedClass_With_ProtectedInternalField_From_OtherAssembly.cs
@@ -1,16 +1,14 @@
-﻿using System;
-
-namespace Minicloner.Tests.OtherAssembly.Fakes.Inheritance
+﻿namespace Minicloner.Tests.OtherAssembly.Fakes.Inheritance
 {
     public class DerivedClass_With_ProtectedInternalField_From_OtherAssembly : BaseClass_With_ProtectedInternalField_From_OtherAssembly
     {
-        protected internal Int32 ProtectedInternalField_In_DerivedClass;
+        protected internal int ProtectedInternalField_In_DerivedClass;
 
-        public void Set_ProtectedInternalField_In_DerivedClass(Int32 int32Parameter)
+        public void Set_ProtectedInternalField_In_DerivedClass(int int32Parameter)
         {
             ProtectedInternalField_In_DerivedClass = int32Parameter;
         }
 
-        public Int32 Get_ProtectedInternalField_In_DerivedClass() => ProtectedInternalField_In_DerivedClass;
+        public int Get_ProtectedInternalField_In_DerivedClass() => ProtectedInternalField_In_DerivedClass;
     }
 }

--- a/test/Minicloner.Tests/Classes/CloneClassesTests.cs
+++ b/test/Minicloner.Tests/Classes/CloneClassesTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Minicloner.Tests.Fakes;
+﻿using Minicloner.Tests.Fakes;
 using Minicloner.Tests.Fakes.Properties;
 using Xunit;
 
@@ -70,7 +69,7 @@ namespace Minicloner.Tests.Classes
             Assert.IsType<Class_With_PublicAutoImplementedProperty>(cloned.ReferenceTypeProperty);
             Assert.NotSame(source.ReferenceTypeProperty, cloned.ReferenceTypeProperty);
 
-            Assert.IsType<Int32>(cloned.ReferenceTypeProperty.PublicAutoImplementedProperty);
+            Assert.IsType<int>(cloned.ReferenceTypeProperty.PublicAutoImplementedProperty);
             Assert.Equal(source.ReferenceTypeProperty.PublicAutoImplementedProperty, cloned.ReferenceTypeProperty.PublicAutoImplementedProperty);
         }
 
@@ -100,7 +99,7 @@ namespace Minicloner.Tests.Classes
             Assert.IsType<Class_With_PublicAutoImplementedProperty>(cloned.ReferenceTypeProperty);
             Assert.NotSame(source.ReferenceTypeProperty, cloned.ReferenceTypeProperty);
 
-            Assert.IsType<Int32>(cloned.ReferenceTypeProperty.PublicAutoImplementedProperty);
+            Assert.IsType<int>(cloned.ReferenceTypeProperty.PublicAutoImplementedProperty);
             Assert.Equal(source.ReferenceTypeProperty.PublicAutoImplementedProperty, cloned.ReferenceTypeProperty.PublicAutoImplementedProperty);
 
             Assert.IsType<Class_With_ReferenceTypeProperty>(cloned.TwoLeveled_ReferenceTypeProperty);
@@ -109,7 +108,7 @@ namespace Minicloner.Tests.Classes
             Assert.IsType<Class_With_PublicAutoImplementedProperty>(cloned.TwoLeveled_ReferenceTypeProperty.ReferenceTypeProperty);
             Assert.NotSame(source.TwoLeveled_ReferenceTypeProperty.ReferenceTypeProperty, cloned.TwoLeveled_ReferenceTypeProperty.ReferenceTypeProperty);
 
-            Assert.IsType<Int32>(cloned.TwoLeveled_ReferenceTypeProperty.ReferenceTypeProperty.PublicAutoImplementedProperty);
+            Assert.IsType<int>(cloned.TwoLeveled_ReferenceTypeProperty.ReferenceTypeProperty.PublicAutoImplementedProperty);
             Assert.Equal(source.TwoLeveled_ReferenceTypeProperty.ReferenceTypeProperty.PublicAutoImplementedProperty, cloned.TwoLeveled_ReferenceTypeProperty.ReferenceTypeProperty.PublicAutoImplementedProperty);
         }
 
@@ -133,7 +132,7 @@ namespace Minicloner.Tests.Classes
                 Assert.IsType<Class_With_PublicAutoImplementedProperty>(cloned[i]);
                 Assert.NotSame(source[i], cloned[i]);
 
-                Assert.IsType<Int32>(cloned[i].PublicAutoImplementedProperty);
+                Assert.IsType<int>(cloned[i].PublicAutoImplementedProperty);
                 Assert.Equal(source[i].PublicAutoImplementedProperty, cloned[i].PublicAutoImplementedProperty);
             }
         }

--- a/test/Minicloner.Tests/CloneArraysTests.cs
+++ b/test/Minicloner.Tests/CloneArraysTests.cs
@@ -8,10 +8,10 @@ namespace Minicloner.Tests
         [Fact]
         public void Clone_EmptyInt32Array()
         {
-            Int32[] array = { };
+            int[] array = { };
             var cloned = new Cloner().Clone(array);
 
-            Assert.IsType<Int32[]>(cloned);
+            Assert.IsType<int[]>(cloned);
             Assert.NotSame(array, cloned);
             Assert.Empty(cloned);
         }
@@ -19,10 +19,10 @@ namespace Minicloner.Tests
         [Fact]
         public void Clone_NonEmptyInt32Array()
         {
-            Int32[] array = { 1, 2, 3, 4, 5 };
+            int[] array = { 1, 2, 3, 4, 5 };
             var cloned = new Cloner().Clone(array);
 
-            Assert.IsType<Int32[]>(cloned);
+            Assert.IsType<int[]>(cloned);
             Assert.NotSame(array, cloned);
             Assert.Equal(array.Rank, cloned.Rank);
             Assert.Equal(array.Length, cloned.Length);
@@ -36,14 +36,14 @@ namespace Minicloner.Tests
         [Fact]
         public void Clone_TwoDimensionalArray()
         {
-            Int32[,] array2D = {
+            int[,] array2D = {
                                 { 1, 2 },
                                 { 3, 4 },
                                 { 5, 6 }
                                };
             var cloned = new Cloner().Clone(array2D);
 
-            Assert.IsType<Int32[,]>(cloned);
+            Assert.IsType<int[,]>(cloned);
             Assert.NotSame(array2D, cloned);
             Assert.Equal(array2D.Rank, cloned.Rank);
             Assert.Equal(array2D.GetLength(0), cloned.GetLength(0));
@@ -61,7 +61,7 @@ namespace Minicloner.Tests
         [Fact]
         public void Clone_ThreeDimensionalArray()
         {
-            Int32[,,] array3D = {
+            int[,,] array3D = {
                                 { { 1, 2 }, { 3, 4 }, { 5, 6 } },
                                 { { 7, 8 }, { 9, 10 }, { 11, 12 } },
                                 { { 13, 14 }, { 15, 16 }, { 17, 18 } },
@@ -69,7 +69,7 @@ namespace Minicloner.Tests
                                };
             var cloned = new Cloner().Clone(array3D);
 
-            Assert.IsType<Int32[,,]>(cloned);
+            Assert.IsType<int[,,]>(cloned);
             Assert.NotSame(array3D, cloned);
             Assert.Equal(array3D.Rank, cloned.Rank);
             Assert.Equal(array3D.GetLength(0), cloned.GetLength(0));
@@ -93,9 +93,9 @@ namespace Minicloner.Tests
         {
             // 1-dimensional array (not vector) has length 5 and index starts in -10.
             // Since it's non 0-based it is not an Int32[] but an Int32[*] with Rank 1
-            var array = Array.CreateInstance(typeof(Int32), new[] { 5 }, new[] { -10 });
+            var array = Array.CreateInstance(typeof(int), new[] { 5 }, new[] { -10 });
             var count = 0;
-            for (int i = array.GetLowerBound(0); i <= array.GetUpperBound(0); i++)
+            for (var i = array.GetLowerBound(0); i <= array.GetUpperBound(0); i++)
             {
                 array.SetValue(count++, i);
             }
@@ -104,7 +104,7 @@ namespace Minicloner.Tests
             var cloned = new Cloner().Clone(array);
 
             // typeof(Int32).MakeArrayType(1) is a multidimensional array with Rank == 1,
-            Assert.IsType(typeof(Int32).MakeArrayType(1), cloned);
+            Assert.IsType(typeof(int).MakeArrayType(1), cloned);
             Assert.NotSame(array, cloned);
             Assert.Equal(array.Rank, cloned.Rank);
             Assert.Equal(array.Length, cloned.Length);
@@ -119,11 +119,11 @@ namespace Minicloner.Tests
         public void Clone_Non0Based_TwoDimensionalArray()
         {
             // 2-dimensional array with lengths 2 and 3 and with indices that starts in -10 and -20.
-            var array = Array.CreateInstance(typeof(Int32), new[] { 2, 3 }, new[] { -10, -20 });
+            var array = Array.CreateInstance(typeof(int), new[] { 2, 3 }, new[] { -10, -20 });
             var count = 0;
-            for (int i = array.GetLowerBound(0); i <= array.GetUpperBound(0); i++)
+            for (var i = array.GetLowerBound(0); i <= array.GetUpperBound(0); i++)
             {
-                for (int j = array.GetLowerBound(1); j <= array.GetUpperBound(1); j++)
+                for (var j = array.GetLowerBound(1); j <= array.GetUpperBound(1); j++)
                 {
                     array.SetValue(count++, i, j);
                 }
@@ -133,7 +133,7 @@ namespace Minicloner.Tests
             var cloned = new Cloner().Clone(array);
 
             // typeof(Int32).MakeArrayType(2) is a multidimensional array with Rank == 2,
-            Assert.IsType(typeof(Int32).MakeArrayType(2), cloned);
+            Assert.IsType(typeof(int).MakeArrayType(2), cloned);
             Assert.NotSame(array, cloned);
             Assert.Equal(array.Rank, cloned.Rank);
             Assert.Equal(array.GetLength(0), cloned.GetLength(0));
@@ -141,7 +141,7 @@ namespace Minicloner.Tests
 
             for (var i = -10; i <= -9; i++)
             {
-                for (int j = -20; j <= -18; j++)
+                for (var j = -20; j <= -18; j++)
                 {
                     Assert.Equal(array.GetValue(i, j), cloned.GetValue(i, j));
                 }

--- a/test/Minicloner.Tests/CloneNullableTypesTests.cs
+++ b/test/Minicloner.Tests/CloneNullableTypesTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xunit;
+﻿using Xunit;
 
 namespace Minicloner.Tests
 {
@@ -8,7 +7,7 @@ namespace Minicloner.Tests
         [Fact]
         public void Clone_NullInt32()
         {
-            Nullable<Int32> nullInt32 = null;
+            int? nullInt32 = null;
             var cloned = new Cloner().Clone(nullInt32);
 
             Assert.Null(cloned);
@@ -17,10 +16,10 @@ namespace Minicloner.Tests
         [Fact]
         public void Clone_NotNullInt32()
         {
-            Nullable<Int32> notNullInt32 = 1;
+            int? notNullInt32 = 1;
             var cloned = new Cloner().Clone(notNullInt32);
 
-            Assert.IsType<Int32>(cloned);
+            Assert.IsType<int>(cloned);
             Assert.NotSame(notNullInt32, cloned);
             Assert.Equal(notNullInt32, cloned);
         }

--- a/test/Minicloner.Tests/CloneObject.cs
+++ b/test/Minicloner.Tests/CloneObject.cs
@@ -16,7 +16,7 @@ namespace Minicloner.Tests
         [Fact]
         public void Clone_NotNullObject()
         {
-            object notNullObject = new object();
+            var notNullObject = new object();
             var cloned = new Cloner().Clone(notNullObject);
 
             Assert.IsType<object>(cloned);

--- a/test/Minicloner.Tests/ClonePrimitiveTypesTests.cs
+++ b/test/Minicloner.Tests/ClonePrimitiveTypesTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xunit;
+﻿using Xunit;
 
 namespace Minicloner.Tests
 {
@@ -8,120 +7,120 @@ namespace Minicloner.Tests
         [Fact]
         public void Clone_Int16()
         {
-            const Int16 someInt16 = 1;
+            const short someInt16 = 1;
             var cloned = new Cloner().Clone(someInt16);
 
-            Assert.IsType<Int16>(cloned);
+            Assert.IsType<short>(cloned);
             Assert.Equal(someInt16, cloned);
         }
 
         [Fact]
         public void Clone_Int32()
         {
-            const Int32 someInt32 = 1;
+            const int someInt32 = 1;
             var cloned = new Cloner().Clone(someInt32);
 
-            Assert.IsType<Int32>(cloned);
+            Assert.IsType<int>(cloned);
             Assert.Equal(someInt32, cloned);
         }
 
         [Fact]
         public void Clone_Int64()
         {
-            const Int64 someInt64 = 1;
+            const long someInt64 = 1;
             var cloned = new Cloner().Clone(someInt64);
 
-            Assert.IsType<Int64>(cloned);
+            Assert.IsType<long>(cloned);
             Assert.Equal(someInt64, cloned);
         }
 
         [Fact]
         public void Clone_UInt16()
         {
-            const UInt16 someInt16 = 1;
+            const ushort someInt16 = 1;
             var cloned = new Cloner().Clone(someInt16);
 
-            Assert.IsType<UInt16>(cloned);
+            Assert.IsType<ushort>(cloned);
             Assert.Equal(someInt16, cloned);
         }
 
         [Fact]
         public void Clone_UInt32()
         {
-            const UInt32 someUInt32 = 1;
+            const uint someUInt32 = 1;
             var cloned = new Cloner().Clone(someUInt32);
 
-            Assert.IsType<UInt32>(cloned);
+            Assert.IsType<uint>(cloned);
             Assert.Equal(someUInt32, cloned);
         }
 
         [Fact]
         public void Clone_UInt64()
         {
-            const UInt64 someUInt64 = 1;
+            const ulong someUInt64 = 1;
             var cloned = new Cloner().Clone(someUInt64);
 
-            Assert.IsType<UInt64>(cloned);
+            Assert.IsType<ulong>(cloned);
             Assert.Equal(someUInt64, cloned);
         }
 
         [Fact]
         public void Clone_Byte()
         {
-            const Byte someByte = 1;
+            const byte someByte = 1;
             var cloned = new Cloner().Clone(someByte);
 
-            Assert.IsType<Byte>(cloned);
+            Assert.IsType<byte>(cloned);
             Assert.Equal(someByte, cloned);
         }
 
         [Fact]
         public void Clone_SByte()
         {
-            const SByte someSByte = 1;
+            const sbyte someSByte = 1;
             var cloned = new Cloner().Clone(someSByte);
 
-            Assert.IsType<SByte>(cloned);
+            Assert.IsType<sbyte>(cloned);
             Assert.Equal(someSByte, cloned);
         }
 
         [Fact]
         public void Clone_Char()
         {
-            const Char someChar = 'A';
+            const char someChar = 'A';
             var cloned = new Cloner().Clone(someChar);
 
-            Assert.IsType<Char>(cloned);
+            Assert.IsType<char>(cloned);
             Assert.Equal(someChar, cloned);
         }
 
         [Fact]
         public void Clone_Single()
         {
-            const Single someSingle = 1f;
+            const float someSingle = 1f;
             var cloned = new Cloner().Clone(someSingle);
 
-            Assert.IsType<Single>(cloned);
+            Assert.IsType<float>(cloned);
             Assert.Equal(someSingle, cloned);
         }
 
         [Fact]
         public void Clone_Double()
         {
-            const Double someDouble = 1d;
+            const double someDouble = 1d;
             var cloned = new Cloner().Clone(someDouble);
 
-            Assert.IsType<Double>(cloned);
+            Assert.IsType<double>(cloned);
             Assert.Equal(someDouble, cloned);
         }
 
         [Fact]
         public void Clone_Boolean()
         {
-            const Boolean someBoolean = true;
+            const bool someBoolean = true;
             var cloned = new Cloner().Clone(someBoolean);
 
-            Assert.IsType<Boolean>(cloned);
+            Assert.IsType<bool>(cloned);
             Assert.Equal(someBoolean, cloned);
         }
 
@@ -132,7 +131,7 @@ namespace Minicloner.Tests
             const decimal someDecimal = 1m;
             var cloned = new Cloner().Clone(someDecimal);
 
-            Assert.IsType<Decimal>(cloned);
+            Assert.IsType<decimal>(cloned);
             Assert.Equal(someDecimal, cloned);
         }
     }

--- a/test/Minicloner.Tests/CloneStringTests.cs
+++ b/test/Minicloner.Tests/CloneStringTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xunit;
+﻿using Xunit;
 
 namespace Minicloner.Tests
 {
@@ -8,7 +7,7 @@ namespace Minicloner.Tests
         [Fact]
         public void Clone_NullString()
         {
-            const String nullString = null;
+            const string nullString = null;
             var cloned = new Cloner().Clone(nullString);
 
             Assert.Null(cloned);
@@ -17,10 +16,10 @@ namespace Minicloner.Tests
         [Fact]
         public void Clone_EmptyString()
         {
-            const String emptyString = "";
+            const string emptyString = "";
             var cloned = new Cloner().Clone(emptyString);
 
-            Assert.IsType<String>(cloned);
+            Assert.IsType<string>(cloned);
             Assert.NotSame(emptyString, cloned);
             Assert.Equal(emptyString, cloned);
         }
@@ -28,10 +27,10 @@ namespace Minicloner.Tests
         [Fact]
         public void Clone_SomeString()
         {
-            const String someString = "qwertyáéíóúñ";
+            const string someString = "qwertyáéíóúñ";
             var cloned = new Cloner().Clone(someString);
 
-            Assert.IsType<String>(cloned);
+            Assert.IsType<string>(cloned);
             Assert.NotSame(someString, cloned);
             Assert.Equal(someString, cloned);
         }

--- a/test/Minicloner.Tests/Fakes/Constructors/Class_With_DefaultConstructor.cs
+++ b/test/Minicloner.Tests/Fakes/Constructors/Class_With_DefaultConstructor.cs
@@ -1,9 +1,7 @@
-﻿using System;
-
-namespace Minicloner.Tests.Fakes.Constructors
+﻿namespace Minicloner.Tests.Fakes.Constructors
 {
     public class Class_With_DefaultConstructor
     {
-        public Int32 Int32Property { get; set; }
+        public int Int32Property { get; set; }
     }
 }

--- a/test/Minicloner.Tests/Fakes/Constructors/Class_With_InternalParameterlessConstructor.cs
+++ b/test/Minicloner.Tests/Fakes/Constructors/Class_With_InternalParameterlessConstructor.cs
@@ -1,11 +1,9 @@
-﻿using System;
-
-namespace Minicloner.Tests.Fakes.Constructors
+﻿namespace Minicloner.Tests.Fakes.Constructors
 {
     public class Class_With_InternalParameterlessConstructor
     {
-        public Int32 Int32Property { get; set; }
-        public Int32 PropertyInitializedInConstructor { get; private set; }
+        public int Int32Property { get; set; }
+        public int PropertyInitializedInConstructor { get; private set; }
 
         internal Class_With_InternalParameterlessConstructor()
         {

--- a/test/Minicloner.Tests/Fakes/Constructors/Class_With_OneParameterConstructor.cs
+++ b/test/Minicloner.Tests/Fakes/Constructors/Class_With_OneParameterConstructor.cs
@@ -1,12 +1,10 @@
-using System;
-
 namespace Minicloner.Tests.Fakes.Constructors
 {
     public class Class_With_OneParameterConstructor
     {
         public int Int32Property { get; private set; }
 
-        public Class_With_OneParameterConstructor(Int32 int32Parameter)
+        public Class_With_OneParameterConstructor(int int32Parameter)
         {
             Int32Property = int32Parameter;
         }

--- a/test/Minicloner.Tests/Fakes/Constructors/Class_With_OneParameterConstructor_And_ParameterlessContructor.cs
+++ b/test/Minicloner.Tests/Fakes/Constructors/Class_With_OneParameterConstructor_And_ParameterlessContructor.cs
@@ -1,12 +1,10 @@
-using System;
-
 namespace Minicloner.Tests.Fakes.Constructors
 {
     public class Class_With_OneParameterConstructor_And_ParameterlessContructor
     {
-        public Int32 Int32Property { get; private set; }
+        public int Int32Property { get; private set; }
 
-        public Class_With_OneParameterConstructor_And_ParameterlessContructor(Int32 int32Parameter)
+        public Class_With_OneParameterConstructor_And_ParameterlessContructor(int int32Parameter)
         {
             Int32Property = int32Parameter;
         }

--- a/test/Minicloner.Tests/Fakes/Constructors/Class_With_PrivateParameterlessConstructor.cs
+++ b/test/Minicloner.Tests/Fakes/Constructors/Class_With_PrivateParameterlessConstructor.cs
@@ -1,11 +1,9 @@
-using System;
-
 namespace Minicloner.Tests.Fakes.Constructors
 {
     public class Class_With_PrivateParameterlessConstructor
     {
-        public Int32 PropertyInitializedInConstructor { get; private set; }
-        public Int32 Int32Property { get; set; }
+        public int PropertyInitializedInConstructor { get; private set; }
+        public int Int32Property { get; set; }
 
         private Class_With_PrivateParameterlessConstructor()
         {

--- a/test/Minicloner.Tests/Fakes/Constructors/Class_With_ProtectedInternalParameterlessConstructor.cs
+++ b/test/Minicloner.Tests/Fakes/Constructors/Class_With_ProtectedInternalParameterlessConstructor.cs
@@ -1,11 +1,9 @@
-﻿using System;
-
-namespace Minicloner.Tests.Fakes.Constructors
+﻿namespace Minicloner.Tests.Fakes.Constructors
 {
     public class Class_With_ProtectedInternalParameterlessConstructor
     {
-        public Int32 Int32Property { get; set; }
-        public Int32 PropertyInitializedInConstructor { get; private set; }
+        public int Int32Property { get; set; }
+        public int PropertyInitializedInConstructor { get; private set; }
 
         protected internal Class_With_ProtectedInternalParameterlessConstructor()
         {

--- a/test/Minicloner.Tests/Fakes/Constructors/Class_With_ProtectedParameterlessConstructor.cs
+++ b/test/Minicloner.Tests/Fakes/Constructors/Class_With_ProtectedParameterlessConstructor.cs
@@ -1,11 +1,9 @@
-﻿using System;
-
-namespace Minicloner.Tests.Fakes.Constructors
+﻿namespace Minicloner.Tests.Fakes.Constructors
 {
     public class Class_With_ProtectedParameterlessConstructor
     {
-        public Int32 Int32Property { get; set; }
-        public Int32 PropertyInitializedInConstructor { get; private set; }
+        public int Int32Property { get; set; }
+        public int PropertyInitializedInConstructor { get; private set; }
 
         protected Class_With_ProtectedParameterlessConstructor()
         {

--- a/test/Minicloner.Tests/Fakes/Constructors/Class_With_PublicParameterlessConstructor.cs
+++ b/test/Minicloner.Tests/Fakes/Constructors/Class_With_PublicParameterlessConstructor.cs
@@ -1,11 +1,9 @@
-using System;
-
 namespace Minicloner.Tests.Fakes.Constructors
 {
     public class Class_With_PublicParameterlessConstructor
     {
-        public Int32 PropertyInitializedInConstructor { get; private set; }
-        public Int32 Int32Property { get; set; }
+        public int PropertyInitializedInConstructor { get; private set; }
+        public int Int32Property { get; set; }
 
         public Class_With_PublicParameterlessConstructor()
         {

--- a/test/Minicloner.Tests/Fakes/Constructors/Class_With_Two_NonParameterlessConstructors.cs
+++ b/test/Minicloner.Tests/Fakes/Constructors/Class_With_Two_NonParameterlessConstructors.cs
@@ -1,17 +1,15 @@
-using System;
-
 namespace Minicloner.Tests.Fakes.Constructors
 {
     public class Class_With_Two_NonParameterlessConstructors
     {
         public int Int32Property { get; private set; }
 
-        public Class_With_Two_NonParameterlessConstructors(Int32 int32Parameter)
+        public Class_With_Two_NonParameterlessConstructors(int int32Parameter)
         {
             Int32Property = int32Parameter;
         }
 
-        public Class_With_Two_NonParameterlessConstructors(Int32 firstInt32Parameter, Int32 secondInt32Parameter)
+        public Class_With_Two_NonParameterlessConstructors(int firstInt32Parameter, int secondInt32Parameter)
         {
             Int32Property = firstInt32Parameter + secondInt32Parameter;
         }

--- a/test/Minicloner.Tests/Fakes/Fields/Class_With_InternalField.cs
+++ b/test/Minicloner.Tests/Fakes/Fields/Class_With_InternalField.cs
@@ -1,9 +1,7 @@
-using System;
-
 namespace Minicloner.Tests.Fakes.Fields
 {
     public class Class_With_InternalField
     {
-        internal Int32 InternalField;
+        internal int InternalField;
     }
 }

--- a/test/Minicloner.Tests/Fakes/Fields/Class_With_PrivateField.cs
+++ b/test/Minicloner.Tests/Fakes/Fields/Class_With_PrivateField.cs
@@ -1,16 +1,14 @@
-using System;
-
 namespace Minicloner.Tests.Fakes.Fields
 {
     public class Class_With_PrivateField
     {
-        private readonly Int32 _privateField;
+        private readonly int _privateField;
 
-        public Class_With_PrivateField(Int32 parameter)
+        public Class_With_PrivateField(int parameter)
         {
             _privateField = parameter;
         }
 
-        public Int32 Get_PrivateField() => _privateField;
+        public int Get_PrivateField() => _privateField;
     }
 }

--- a/test/Minicloner.Tests/Fakes/Fields/Class_With_ProtectedField.cs
+++ b/test/Minicloner.Tests/Fakes/Fields/Class_With_ProtectedField.cs
@@ -1,16 +1,14 @@
-using System;
-
 namespace Minicloner.Tests.Fakes.Fields
 {
     public class Class_With_ProtectedField
     {
-        protected readonly Int32 ProtectedField;
+        protected readonly int ProtectedField;
 
         public Class_With_ProtectedField(int parameter)
         {
             ProtectedField = parameter;
         }
 
-        public Int32 Get_ProtectedField() => ProtectedField;
+        public int Get_ProtectedField() => ProtectedField;
     }
 }

--- a/test/Minicloner.Tests/Fakes/Fields/Class_With_ProtectedInternalField.cs
+++ b/test/Minicloner.Tests/Fakes/Fields/Class_With_ProtectedInternalField.cs
@@ -1,9 +1,7 @@
-using System;
-
 namespace Minicloner.Tests.Fakes.Fields
 {
     public class Class_With_ProtectedInternalField
     {
-        protected internal Int32 ProtectedInternalField;
+        protected internal int ProtectedInternalField;
     }
 }

--- a/test/Minicloner.Tests/Fakes/Fields/Class_With_PublicField.cs
+++ b/test/Minicloner.Tests/Fakes/Fields/Class_With_PublicField.cs
@@ -1,9 +1,7 @@
-using System;
-
 namespace Minicloner.Tests.Fakes.Fields
 {
     public class Class_With_PublicField
     {
-        public Int32 PublicField;
+        public int PublicField;
     }
 }

--- a/test/Minicloner.Tests/Fakes/Inheritance/BaseClass_With_InternalField.cs
+++ b/test/Minicloner.Tests/Fakes/Inheritance/BaseClass_With_InternalField.cs
@@ -1,9 +1,7 @@
-﻿using System;
-
-namespace Minicloner.Tests.Fakes.Inheritance
+﻿namespace Minicloner.Tests.Fakes.Inheritance
 {
     public class BaseClass_With_InternalField
     {
-        internal Int32 InternalField_In_BaseClass;
+        internal int InternalField_In_BaseClass;
     }
 }

--- a/test/Minicloner.Tests/Fakes/Inheritance/BaseClass_With_PrivateField.cs
+++ b/test/Minicloner.Tests/Fakes/Inheritance/BaseClass_With_PrivateField.cs
@@ -1,13 +1,11 @@
-﻿using System;
-
-namespace Minicloner.Tests.Fakes.Inheritance
+﻿namespace Minicloner.Tests.Fakes.Inheritance
 {
     public class BaseClass_With_PrivateField
     {
-        private Int32 _privateFieldInBaseClass;
+        private int _privateFieldInBaseClass;
 
-        public void Set_PrivateField_In_BaseClass(Int32 int32Parameter) => _privateFieldInBaseClass = int32Parameter;
+        public void Set_PrivateField_In_BaseClass(int int32Parameter) => _privateFieldInBaseClass = int32Parameter;
 
-        public Int32 Get_PrivateField_In_BaseClass() => _privateFieldInBaseClass;
+        public int Get_PrivateField_In_BaseClass() => _privateFieldInBaseClass;
     }
 }

--- a/test/Minicloner.Tests/Fakes/Inheritance/BaseClass_With_ProtectedField.cs
+++ b/test/Minicloner.Tests/Fakes/Inheritance/BaseClass_With_ProtectedField.cs
@@ -1,13 +1,11 @@
-﻿using System;
-
-namespace Minicloner.Tests.Fakes.Inheritance
+﻿namespace Minicloner.Tests.Fakes.Inheritance
 {
     public class BaseClass_With_ProtectedField
     {
-        protected Int32 ProtectedField_In_BaseClass;
+        protected int ProtectedField_In_BaseClass;
 
-        public void Set_ProtectedField_In_BaseClass(Int32 int32Parameter) => ProtectedField_In_BaseClass = int32Parameter;
+        public void Set_ProtectedField_In_BaseClass(int int32Parameter) => ProtectedField_In_BaseClass = int32Parameter;
 
-        public Int32 Get_ProtectedField_In_BaseClass() => ProtectedField_In_BaseClass;
+        public int Get_ProtectedField_In_BaseClass() => ProtectedField_In_BaseClass;
     }
 }

--- a/test/Minicloner.Tests/Fakes/Inheritance/BaseClass_With_ProtectedInternalField.cs
+++ b/test/Minicloner.Tests/Fakes/Inheritance/BaseClass_With_ProtectedInternalField.cs
@@ -1,9 +1,7 @@
-﻿using System;
-
-namespace Minicloner.Tests.Fakes.Inheritance
+﻿namespace Minicloner.Tests.Fakes.Inheritance
 {
     public class BaseClass_With_ProtectedInternalField
     {
-        protected internal Int32 ProtectedInternalField_In_BaseClass;
+        protected internal int ProtectedInternalField_In_BaseClass;
     }
 }

--- a/test/Minicloner.Tests/Fakes/Inheritance/BaseClass_With_PublicField.cs
+++ b/test/Minicloner.Tests/Fakes/Inheritance/BaseClass_With_PublicField.cs
@@ -1,9 +1,7 @@
-﻿using System;
-
-namespace Minicloner.Tests.Fakes.Inheritance
+﻿namespace Minicloner.Tests.Fakes.Inheritance
 {
     public class BaseClass_With_PublicField
     {
-        public Int32 PublicField_In_BaseClass;
+        public int PublicField_In_BaseClass;
     }
 }

--- a/test/Minicloner.Tests/Fakes/Inheritance/DerivedClass_With_InternalField.cs
+++ b/test/Minicloner.Tests/Fakes/Inheritance/DerivedClass_With_InternalField.cs
@@ -1,9 +1,7 @@
-﻿using System;
-
-namespace Minicloner.Tests.Fakes.Inheritance
+﻿namespace Minicloner.Tests.Fakes.Inheritance
 {
     public class DerivedClass_With_InternalField : BaseClass_With_InternalField
     {
-        internal Int32 InternalField_In_DerivedClass;
+        internal int InternalField_In_DerivedClass;
     }
 }

--- a/test/Minicloner.Tests/Fakes/Inheritance/DerivedClass_With_PrivateField.cs
+++ b/test/Minicloner.Tests/Fakes/Inheritance/DerivedClass_With_PrivateField.cs
@@ -1,13 +1,11 @@
-﻿using System;
-
-namespace Minicloner.Tests.Fakes.Inheritance
+﻿namespace Minicloner.Tests.Fakes.Inheritance
 {
     public class DerivedClass_With_PrivateField : BaseClass_With_PrivateField
     {
-        private Int32 _privateFieldInDerivedClass;
+        private int _privateFieldInDerivedClass;
 
-        public void Set_PrivateField_In_DerivedClass(Int32 int32Parameter) => _privateFieldInDerivedClass = int32Parameter;
+        public void Set_PrivateField_In_DerivedClass(int int32Parameter) => _privateFieldInDerivedClass = int32Parameter;
 
-        public Int32 Get_PrivateField_In_DerivedClass() => _privateFieldInDerivedClass;
+        public int Get_PrivateField_In_DerivedClass() => _privateFieldInDerivedClass;
     }
 }

--- a/test/Minicloner.Tests/Fakes/Inheritance/DerivedClass_With_ProtectedField.cs
+++ b/test/Minicloner.Tests/Fakes/Inheritance/DerivedClass_With_ProtectedField.cs
@@ -1,13 +1,11 @@
-﻿using System;
-
-namespace Minicloner.Tests.Fakes.Inheritance
+﻿namespace Minicloner.Tests.Fakes.Inheritance
 {
     public class DerivedClass_With_ProtectedField : BaseClass_With_ProtectedField
     {
-        protected Int32 ProtectedField_In_DerivedClass;
+        protected int ProtectedField_In_DerivedClass;
 
-        public void Set_ProtectedField_In_DerivedClass(Int32 int32Parameter) => ProtectedField_In_DerivedClass = int32Parameter;
+        public void Set_ProtectedField_In_DerivedClass(int int32Parameter) => ProtectedField_In_DerivedClass = int32Parameter;
 
-        public Int32 Get_ProtectedField_In_DerivedClass() => ProtectedField_In_DerivedClass;
+        public int Get_ProtectedField_In_DerivedClass() => ProtectedField_In_DerivedClass;
     }
 }

--- a/test/Minicloner.Tests/Fakes/Inheritance/DerivedClass_With_ProtectedInternalField.cs
+++ b/test/Minicloner.Tests/Fakes/Inheritance/DerivedClass_With_ProtectedInternalField.cs
@@ -1,9 +1,7 @@
-﻿using System;
-
-namespace Minicloner.Tests.Fakes.Inheritance
+﻿namespace Minicloner.Tests.Fakes.Inheritance
 {
     public class DerivedClass_With_ProtectedInternalField : BaseClass_With_ProtectedInternalField
     {
-        protected internal Int32 ProtectedInternalField_In_DerivedClass;
+        protected internal int ProtectedInternalField_In_DerivedClass;
     }
 }

--- a/test/Minicloner.Tests/Fakes/Inheritance/DerivedClass_With_PublicField.cs
+++ b/test/Minicloner.Tests/Fakes/Inheritance/DerivedClass_With_PublicField.cs
@@ -1,9 +1,7 @@
-﻿using System;
-
-namespace Minicloner.Tests.Fakes.Inheritance
+﻿namespace Minicloner.Tests.Fakes.Inheritance
 {
     public class DerivedClass_With_PublicField : BaseClass_With_PublicField
     {
-        public Int32 PublicField_In_DerivedClass;
+        public int PublicField_In_DerivedClass;
     }
 }

--- a/test/Minicloner.Tests/Fakes/Properties/Class_With_PrivateGetter.cs
+++ b/test/Minicloner.Tests/Fakes/Properties/Class_With_PrivateGetter.cs
@@ -1,11 +1,9 @@
-using System;
-
 namespace Minicloner.Tests.Fakes.Properties
 {
     public class Class_With_PrivateGetter
     {
-        public Int32 Int32Property_With_PrivateGetter { private get; set; }
+        public int Int32Property_With_PrivateGetter { private get; set; }
 
-        public Int32 Get_Int32Property_With_PrivateGetter() => Int32Property_With_PrivateGetter;
+        public int Get_Int32Property_With_PrivateGetter() => Int32Property_With_PrivateGetter;
     }
 }

--- a/test/Minicloner.Tests/Fakes/Properties/Class_With_PrivateSetter.cs
+++ b/test/Minicloner.Tests/Fakes/Properties/Class_With_PrivateSetter.cs
@@ -1,11 +1,9 @@
-using System;
-
 namespace Minicloner.Tests.Fakes.Properties
 {
     public class Class_With_PrivateSetter
     {
-        public Int32 Int32Property_With_PrivateSetter { get; private set; }
+        public int Int32Property_With_PrivateSetter { get; private set; }
 
-        public void Set_Int32Property_With_PrivateSetter(Int32 int32Parameter) => Int32Property_With_PrivateSetter = int32Parameter;
+        public void Set_Int32Property_With_PrivateSetter(int int32Parameter) => Int32Property_With_PrivateSetter = int32Parameter;
     }
 }

--- a/test/Minicloner.Tests/Fakes/Properties/Class_With_PublicAutoImplementedProperty.cs
+++ b/test/Minicloner.Tests/Fakes/Properties/Class_With_PublicAutoImplementedProperty.cs
@@ -1,9 +1,7 @@
-using System;
-
 namespace Minicloner.Tests.Fakes.Properties
 {
     public class Class_With_PublicAutoImplementedProperty
     {
-        public Int32 PublicAutoImplementedProperty { get; set; }
+        public int PublicAutoImplementedProperty { get; set; }
     }
 }

--- a/test/Minicloner.Tests/Fakes/Struct_With_PublicValueTypeField.cs
+++ b/test/Minicloner.Tests/Fakes/Struct_With_PublicValueTypeField.cs
@@ -1,9 +1,7 @@
-﻿using System;
-
-namespace Minicloner.Tests.Fakes
+﻿namespace Minicloner.Tests.Fakes
 {
     public struct Struct_With_PublicValueTypeField
     {
-        public Int32 PublicInt32Field;
+        public int PublicInt32Field;
     }
 }


### PR DESCRIPTION
- Updated VisualStudioVersion to 15.0.26228.10
- Explicitly marked FormatterServices and StringReflectionExtensions as internal classes
- Changed access modifier of StringReflectionExtensions.CopyDelegate from public to private