### PR TITLE
Workaround for strange dotnet outdated issue

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
     inputs:
       command: 'custom'
       custom: 'outdated'
-      arguments: '--fail-on-updates'
+      arguments: '--fail-on-updates .'
 
   - task: DotNetCoreCLI@2
     displayName: 'Build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,20 @@ jobs:
       custom: '--info'
 
   - task: DotNetCoreCLI@2
+    displayName: 'Install dotnet-outdated'
+    inputs:
+      command: 'custom'
+      custom: 'tool'
+      arguments: 'install --global dotnet-outdated-tool'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet outdated'
+    inputs:
+      command: 'custom'
+      custom: 'outdated'
+      arguments: '--fail-on-updates'
+
+  - task: DotNetCoreCLI@2
     displayName: 'Build'
     inputs:
       command: 'build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ jobs:
     inputs:
       command: 'custom'
       custom: 'tool'
-      arguments: 'install --global dotnet-outdated-tool'
+      arguments: 'update --global dotnet-outdated-tool'
 
   - task: DotNetCoreCLI@2
     displayName: 'dotnet outdated'
@@ -111,4 +111,3 @@ jobs:
       testResultsFiles: '**/$(imageName)-netcoreapp2.0*.trx'
       testRunTitle: '$(imageName) - .NET Core 2.0'
       failTaskOnFailedTests: true
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,12 @@ jobs:
       arguments: 'update --global dotnet-outdated-tool'
 
   - task: DotNetCoreCLI@2
+    displayName: 'dotnet restore'
+    inputs:
+      command: 'custom'
+      custom: 'restore'
+
+  - task: DotNetCoreCLI@2
     displayName: 'dotnet outdated'
     inputs:
       command: 'custom'

--- a/build.ps1
+++ b/build.ps1
@@ -58,7 +58,7 @@ Invoke-Task AutomatedBuild {
     }
 
     Invoke-Task Dotnet-outdated {
-        dotnet outdated --fail-on-updates
+        dotnet outdated --fail-on-updates .
     }
 
     Invoke-Task Build {

--- a/build.ps1
+++ b/build.ps1
@@ -53,6 +53,14 @@ Invoke-Task AutomatedBuild {
         dotnet clean --configuration Release
     }
 
+    Invoke-Task Install-Dotnet-Outdated {
+        dotnet tool update --global dotnet-outdated-tool
+    }
+
+    Invoke-Task Dotnet-outdated {
+        dotnet outdated --fail-on-updates
+    }
+
     Invoke-Task Build {
         dotnet build --configuration Release
     }


### PR DESCRIPTION
This is a workaround for the dotnet-outdated issue [When running concurrent jobs in Azure Pipelines only macOS-10.15 agent seems to run dotnet outdated correctly](https://github.com/dotnet-outdated/dotnet-outdated/issues/63)

Results can be reviewed here https://dev.azure.com/coderpatros/test/_build/results?buildId=1764&view=results